### PR TITLE
Remove GFW-specifc stuff from UUID

### DIFF
--- a/ais_tools/message.py
+++ b/ais_tools/message.py
@@ -76,4 +76,4 @@ class Message(dict):
     @classmethod
     def stream(cls, messages):
         for msg in messages:
-            yield Message(msg)
+            yield Message(msg.strip())

--- a/ais_tools/message.py
+++ b/ais_tools/message.py
@@ -8,13 +8,12 @@ import posixpath as pp
 import uuid
 
 
-class GFW_UUID:
+class UUID:
     """
-    ported from https://github.com/GlobalFishingWatch/pipe-tools
+    Create a UUID from a set of args
     """
 
-    UUID_URL_BASE = '//globalfishingwatch.org'
-    SOURCE = 'source'
+    UUID_URL_BASE = 'ais-tools'
 
     def __init__(self, *args):
         self.uuid = self.create_uuid(*args)
@@ -43,6 +42,7 @@ class Message(dict):
             elif isinstance(message, dict):
                 self.update(message)
             elif isinstance(message, str):
+                message = message.strip()
                 if message[0] == '{':
                     # looks like json, try to parse it
                     self.update(json.loads(message))
@@ -62,11 +62,7 @@ class Message(dict):
         return self
 
     def create_uuid(self):
-        """
-        using this the same way as in https://github.com/GlobalFishingWatch/pipe-orbcomm so it should
-        generate the same uuid given the same NMEA string and source='orbcomm'
-        """
-        return str(GFW_UUID(GFW_UUID.SOURCE, self.get('source', ''), self.get('nmea', '')))
+        return str(UUID(self.get('source', 'ais-tools'), self.get('nmea', '')))
 
     def add_uuid(self, overwrite=False):
         if self.get('uuid') is None or overwrite:
@@ -76,4 +72,4 @@ class Message(dict):
     @classmethod
     def stream(cls, messages):
         for msg in messages:
-            yield Message(msg.strip())
+            yield Message(msg)

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,11 +1,11 @@
 import pytest
 from ais_tools.message import Message
-from ais_tools.message import GFW_UUID
+from ais_tools.message import UUID
 import itertools as it
 
 
-def test_gfw_uuid():
-    assert str(GFW_UUID('test')) == 'c3757317-71ed-5251-bec6-fa01f05cb8dc'
+def test_uuid():
+    assert str(UUID('test')) == '4e782d81-81ae-5eab-93eb-ddb536abd3da'
 
 
 @pytest.mark.parametrize("msg,expected", [
@@ -37,10 +37,10 @@ def test_add_source(msg, source, overwrite, expected):
 
 
 @pytest.mark.parametrize("msg,overwrite,expected", [
-    ({}, False, {'nmea': '', 'uuid': '7b16d688-bafc-55ad-8f2b-ca76c2a4eb4f'}),
-    ({'nmea': '!AVIDM123'}, False, {'nmea': '!AVIDM123', 'uuid': 'a40aa816-9e5b-5d39-bed4-eecf791af8e1'}),
+    ({}, False, {'nmea': '', 'uuid': '02638ec7-57a1-513b-9a77-bf1e9ab8168e'}),
+    ({'nmea': '!AVIDM123'}, False, {'nmea': '!AVIDM123', 'uuid': 'a12758f1-dc54-5441-a3ff-10018331c665'}),
     ({'nmea': '!AVIDM123', 'uuid': 'old'}, False, {'nmea': '!AVIDM123', 'uuid': 'old'}),
-    ({'nmea': '!AVIDM123', 'uuid': 'old'}, True, {'nmea': '!AVIDM123', 'uuid': 'a40aa816-9e5b-5d39-bed4-eecf791af8e1'}),
+    ({'nmea': '!AVIDM123', 'uuid': 'old'}, True, {'nmea': '!AVIDM123', 'uuid': 'a12758f1-dc54-5441-a3ff-10018331c665'}),
 ])
 def test_add_uuid(msg, overwrite, expected):
     assert Message(msg).add_uuid(overwrite) == expected
@@ -86,7 +86,7 @@ def test_message_stream_add_uuid(old_uuid, add_uuid, overwrite):
     messages = [{'nmea': '!AVIDM123', 'source': 'test', 'uuid': old_uuid}]
 
     if add_uuid and (overwrite or old_uuid is None):
-        expected = '0ce10f94-d475-5f50-826f-23541125f73a'
+        expected = '84ce1423-6ae0-5db6-b55a-11c28bb3a7b4'
     else:
         expected = old_uuid
     messages = Message.stream(messages)


### PR DESCRIPTION
Closes #7 Remove GFW-specifc stuff from UUID

Now it just uses the string 'ais-tools' as the base of the URL string used to build a UUID instead of 'globafishingwatch.org'
