### PR TITLE
New flag use-station-id for mulipart message join

### DIFF
--- a/ais_tools/cli.py
+++ b/ais_tools/cli.py
@@ -137,9 +137,9 @@ def encode(input, output):
               help="Only match message parts if the station_id from the tagblock also matches"
               )
 def join_multipart(input, output, max_time, max_count, use_station_id):
-    for nmea in safe_join_multipart_stream(input, 
-                                           max_time_window=max_time, 
-                                           max_message_window=max_count, 
+    for nmea in safe_join_multipart_stream(input,
+                                           max_time_window=max_time,
+                                           max_message_window=max_count,
                                            use_station_id=use_station_id):
         output.write(nmea)
         output.write('\n')

--- a/ais_tools/cli.py
+++ b/ais_tools/cli.py
@@ -133,7 +133,13 @@ def encode(input, output):
               help="Retain an unmatched message part in the buffer until at least max_count messages have"
                    "been seen after the message part was added to the buffer"
               )
-def join_multipart(input, output, max_time, max_count):
-    for nmea in safe_join_multipart_stream(input, max_time_window=max_time, max_message_window=max_count):
+@click.option('--use-station-id/--no-use-station-id', default=True,
+              help="Only match message parts if the station_id from the tagblock also matches"
+              )
+def join_multipart(input, output, max_time, max_count, use_station_id):
+    for nmea in safe_join_multipart_stream(input, 
+                                           max_time_window=max_time, 
+                                           max_message_window=max_count, 
+                                           use_station_id=use_station_id):
         output.write(nmea)
         output.write('\n')

--- a/ais_tools/nmea.py
+++ b/ais_tools/nmea.py
@@ -91,7 +91,11 @@ def safe_join_multipart_stream(lines, max_time_window=500, max_message_window=10
         yield line
 
 
-def join_multipart_stream(lines, max_time_window=500, max_message_window=1000, ignore_decode_errors=False, use_station_id=True):
+def join_multipart_stream(lines,
+                          max_time_window=500,
+                          max_message_window=1000,
+                          ignore_decode_errors=False,
+                          use_station_id=True):
     """
     Takes a stream of nmea text lines and tries to find the matching parts of multi part messages
     which may not be adjacent in the stream and may come out of order.
@@ -126,7 +130,7 @@ def join_multipart_stream(lines, max_time_window=500, max_message_window=1000, i
             # - tagblock_channel is the AIS RF channel (either A or B) that was used for transmission
 
             station_id = tagblock.get('tagblock_station') if use_station_id else None
-            key = (total_parts, station_id, tagblock.get('tagblock_id'), 
+            key = (total_parts, station_id, tagblock.get('tagblock_id'),
                    tagblock.get('tagblock_channel'))
 
             # pack up the message part

--- a/ais_tools/nmea.py
+++ b/ais_tools/nmea.py
@@ -75,7 +75,7 @@ def join_multipart(lines):
     raise DecodeError("all lines to be joined must start with the same character, either '\\' or '!'")
 
 
-def safe_join_multipart_stream(lines, max_time_window=500, max_message_window=1000):
+def safe_join_multipart_stream(lines, max_time_window=500, max_message_window=1000, use_station_id=True):
     """
     Same as join_multipart_stream but for any message that cannot decoded, it will just emit
     that message back out and not raise a DecodeError exception
@@ -84,13 +84,14 @@ def safe_join_multipart_stream(lines, max_time_window=500, max_message_window=10
             lines,
             max_time_window=max_time_window,
             max_message_window=max_message_window,
-            ignore_decode_errors=True
+            ignore_decode_errors=True,
+            use_station_id=use_station_id
             )
     for line in lines:
         yield line
 
 
-def join_multipart_stream(lines, max_time_window=500, max_message_window=1000, ignore_decode_errors=False):
+def join_multipart_stream(lines, max_time_window=500, max_message_window=1000, ignore_decode_errors=False, use_station_id=True):
     """
     Takes a stream of nmea text lines and tries to find the matching parts of multi part messages
     which may not be adjacent in the stream and may come out of order.
@@ -123,8 +124,10 @@ def join_multipart_stream(lines, max_time_window=500, max_message_window=1000, i
             # - tagblock_station is the source of the message and may not have a value
             # - tagblock_id is a sequence number that is the same for all message parts, but it is not unique
             # - tagblock_channel is the AIS RF channel (either A or B) that was used for transmission
-            key = (total_parts, tagblock.get('tagblock_station'),
-                   tagblock.get('tagblock_id'), tagblock.get('tagblock_channel'))
+
+            station_id = tagblock.get('tagblock_station') if use_station_id else None
+            key = (total_parts, station_id, tagblock.get('tagblock_id'), 
+                   tagblock.get('tagblock_channel'))
 
             # pack up the message part
             # - tagblock_sentence is the index of this part relative to the other parts, where the first part is 1

--- a/tests/test_nmea.py
+++ b/tests/test_nmea.py
@@ -111,6 +111,21 @@ def test_join_multipart_stream_pairs(nmea):
     assert combined == [''.join(nmea)]
 
 
+@pytest.mark.parametrize("nmea", [
+    (['\\g:1-2-1786,s:MAEROSPACE-C,c:1516060792*31'
+      '\\!AIVDM,2,1,6,B,55R;bN02>brS<D=6220pt8hF0t4f222222222216BHGC84HC0Gm5p2j28888,0*56',
+      '\\g:2-2-1786*55\\!AIVDM,2,2,6,B,88888888880,2*21']),
+])
+def test_join_multipart_stream_station_id_mismatch(nmea):
+    combined = list(join_multipart_stream(nmea, use_station_id=True))
+    assert len(combined) == 2
+    assert combined == nmea
+
+    combined = list(join_multipart_stream(nmea, use_station_id=False))
+    assert len(combined) == 1
+    assert combined == [''.join(nmea)]
+
+
 def test_join_multipart_stream_mixed():
     nmea = [
         '\\t:1,s:station1*00\\!AIVDM,1,1,1,A,@,0*57',


### PR DESCRIPTION
Closes #10 

Add a new parameter for `ais-tools join-multipart` that controls whether the station_id value from the tagblock is considered when matching up message parts from a stream of messages