### PR TITLE
Release 0.1.3

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/ais_tools/__init__.py
+++ b/ais_tools/__init__.py
@@ -2,12 +2,12 @@
 Tools for managing AIS messages
 """
 
-__version__ = '0.1.2-alpha'
+__version__ = '0.1.3-alpha'
 __author__ = 'Paul Woods'
 __email__ = 'paul@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/ais-tools'
 __license__ = """
-Copyright 2020 Global Fishing Watch
+Copyright 2022 Global Fishing Watch
 
 Authors:
 Paul Woods <paul@globalfishingwatch.org>


### PR DESCRIPTION
Closes #18

Changes
* new param in join_multipart_stream to allow ignoring station_id tagblok field when matching up multi-line messages
* updates for message type 24 to cover the latest ITU spec - extract mothership mmsi and vendor id
* Parser for type 8 messages