### PR TITLE
Re-factor tagblock parsing

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,6 @@ jobs:
         os:
           - macos-11
           - ubuntu-latest
-          - windows-latest
         python-version:
           - "3.7"
           - "3.8"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,17 +12,30 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
-
+        os:
+          - macos-11
+          - ubuntu-latest
+          - windows-latest
+        python-version:
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+        include:
+          - os: "ubuntu-20.04"
+            python-version: "3.6"
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout source
+      uses: actions/checkout@v4
+
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -41,7 +41,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 pytest
         pip install -e .\[dev\]
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install -r requirements.txt
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,7 +29,7 @@ jobs:
             python-version: "3.6"
     steps:
     - name: Checkout source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4

--- a/ais_tools/__init__.py
+++ b/ais_tools/__init__.py
@@ -2,7 +2,7 @@
 Tools for managing AIS messages
 """
 
-__version__ = 'v0.1.4'
+__version__ = 'v0.1.5.dev1'
 __author__ = 'Paul Woods'
 __email__ = 'paul@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/ais-tools'

--- a/ais_tools/nmea.py
+++ b/ais_tools/nmea.py
@@ -25,21 +25,16 @@ def expand_nmea(line, validate_checksum=False):
         raise DecodeError('Invalid checksum')
 
     try:
-        tagblock['tagblock_groupsize'] = int(fields[1])
-        tagblock['tagblock_sentence'] = int(fields[2])
-        if fields[3] != '':
-            tagblock['tagblock_id'] = int(fields[3])
+        if 'tagblock_groupsize' not in tagblock:
+            tagblock['tagblock_groupsize'] = int(fields[1])
+            tagblock['tagblock_sentence'] = int(fields[2])
+            if fields[3] != '':
+                tagblock['tagblock_id'] = int(fields[3])
         tagblock['tagblock_channel'] = fields[4]
         body = fields[5]
         pad = int(nmea.split('*')[0][-1])
     except ValueError:
         raise DecodeError('Unable to convert field to int in nmea message')
-
-    if 'tagblock_group' in tagblock:
-        tagblock_group = tagblock.get('tagblock_group', {})
-        del tagblock['tagblock_group']
-        group_fields = {'tagblock_' + k: v for k, v in tagblock_group.items()}
-        tagblock.update(group_fields)
 
     return tagblock, body, pad
 

--- a/ais_tools/nmea.py
+++ b/ais_tools/nmea.py
@@ -4,7 +4,8 @@ import re
 
 from ais import DecodeError
 from ais_tools.checksum import is_checksum_valid
-from ais_tools.tagblock import parseTagBlock
+from ais_tools.tagblock import split_tagblock
+from ais_tools.tagblock import decode_tagblock
 
 REGEX_BANG = re.compile(r'(![^!]+)')
 REGEX_BACKSLASH = re.compile(r'(\\[^\\]+\\![^!\\]+)')
@@ -12,10 +13,8 @@ REGEX_BACKSLASH_BANG = re.compile(r'(\\![^!\\]+)')
 
 
 def expand_nmea(line, validate_checksum=False):
-    try:
-        tagblock, nmea = parseTagBlock(line)
-    except ValueError as e:
-        raise DecodeError('Failed to parse tagblock (%s) %s' % (str(e), line))
+    tagblock_str, nmea = split_tagblock(line)
+    tagblock = decode_tagblock(tagblock_str, validate_checksum=validate_checksum)
 
     nmea = nmea.strip()
     fields = nmea.split(',')

--- a/ais_tools/tagblock.py
+++ b/ais_tools/tagblock.py
@@ -86,6 +86,7 @@ def add_tagblock(tagblock, nmea, overwrite=True):
 
     return join_tagblock(tagblock, nmea)
 
+
 tagblock_fields = {
     'c': 'tagblock_timestamp',
     'n': 'tagblock_line_count',
@@ -95,7 +96,7 @@ tagblock_fields = {
     't': 'tagblock_text',
 }
 
-tagblock_fields_reversed = {v:k for k, v in tagblock_fields.items()}
+tagblock_fields_reversed = {v: k for k, v in tagblock_fields.items()}
 
 tagblock_group_fields = ["tagblock_sentence", "tagblock_groupsize", "tagblock_id"]
 
@@ -104,7 +105,7 @@ def encode_tagblock(**kwargs):
     group_fields = {}
     fields = {}
 
-    for k,v in kwargs.items():
+    for k, v in kwargs.items():
         if k in tagblock_group_fields:
             group_fields[k] = str(v)
         elif k in tagblock_fields_reversed:

--- a/ais_tools/tagblock.py
+++ b/ais_tools/tagblock.py
@@ -5,10 +5,10 @@ from ais import DecodeError
 from ais_tools.checksum import checksumstr
 from ais_tools.checksum import is_checksum_valid
 
-import warnings
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    from ais.stream import parseTagBlock                # noqa: F401
+# import warnings
+# with warnings.catch_warnings():
+#     warnings.simplefilter("ignore")
+#     from ais.stream import parseTagBlock                # noqa: F401
 
 TAGBLOCK_T_FORMAT = '%Y-%m-%d %H.%M.%S'
 
@@ -58,7 +58,9 @@ def split_tagblock(nmea):
     """
     tagblock = ''
     if nmea.startswith("\\") and not nmea.startswith("\\!"):
-        tagblock, nmea = nmea[1:].split("\\", 1)
+        parts = nmea[1:].split("\\", 1)
+        if len(parts) == 2:
+            tagblock, nmea = parts
     return tagblock, nmea
 
 

--- a/ais_tools/tagblock.py
+++ b/ais_tools/tagblock.py
@@ -132,19 +132,22 @@ def decode_tagblock(tagblock_str, validate_checksum=False):
         raise DecodeError('Invalid checksum')
 
     for field in tagblock.split(","):
-        key, value = field.split(":")
+        try:
+            key, value = field.split(":")
 
-        if key == 'g':
-            fields.update(dict(zip(tagblock_group_fields,
-                               [int(part) for part in value.split("-")])))
-        else:
-            if key in ['n', 'r']:
-                value = int(value)
-            elif key == 'c':
-                value = int(value)
-                if value > 40000000000:
-                    value = value / 1000.0
+            if key == 'g':
+                fields.update(dict(zip(tagblock_group_fields,
+                                   [int(part) for part in value.split("-")])))
+            else:
+                if key in ['n', 'r']:
+                    value = int(value)
+                elif key == 'c':
+                    value = int(value)
+                    if value > 40000000000:
+                        value = value / 1000.0
 
-            fields[tagblock_fields.get(key, key)] = value
+                fields[tagblock_fields.get(key, key)] = value
+        except ValueError:
+            raise DecodeError('Unable to decode tagblock string')
 
     return fields

--- a/tests/test_checksum.py
+++ b/tests/test_checksum.py
@@ -3,7 +3,11 @@ import pytest
 from ais_tools.checksum import checksum
 from ais_tools.checksum import is_checksum_valid
 from ais_tools.checksum import checksumstr
-from ais.stream.checksum import checksumStr
+
+import warnings
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    from ais.stream.checksum import checksumStr as libais_checksumstr
 
 
 @pytest.mark.parametrize("str,expected", [
@@ -27,7 +31,7 @@ def test_checksum_str(str, expected):
 
     assert actual == expected
     if len(str) > 1:
-        assert actual == checksumStr(str)
+        assert actual == libais_checksumstr(str)
 
 
 @pytest.mark.parametrize("str,expected", [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,9 @@ from ais_tools.cli import decode
 from ais_tools.cli import encode
 from ais_tools.cli import join_multipart
 from ais_tools.cli import cli
-from ais_tools.tagblock import parseTagBlock
+from ais_tools.tagblock import split_tagblock
+from ais_tools.tagblock import decode_tagblock
+# from ais_tools.tagblock import parseTagBlock
 
 
 def test_help():
@@ -27,7 +29,9 @@ def test_add_tagblock():
     result = runner.invoke(add_tagblock, input=input, args=args)
     assert not result.exception
 
-    tagblock, nmea = parseTagBlock(result.output.strip())
+    tagblock_str, nmea = split_tagblock(result.output.strip())
+    tagblock = decode_tagblock(tagblock_str)
+    # tagblock, nmea = parseTagBlock(result.output.strip())
     assert nmea == input
     assert tagblock['tagblock_station'] == 'test'
 

--- a/tests/test_nmea.py
+++ b/tests/test_nmea.py
@@ -37,14 +37,14 @@ def test_expand_nmea(line, expected):
     '!AIVDM,1,1,'
     "\\s:bad-nmea,q:u,c:1509502436,T:2017-11-01 02.13.56*50\\!AIVDM,1,1,,A,13`el0gP000H=3JN9jb>4?wb0>`<,0*00",
     "\\s:missing-tagblock-separator,q:u,c:1509502436,T:2017-11-01 02.13.56*50!AIVDM,1,1,,A,13`el0gP000H=3JN9jb>4?wb0>`<,0*00",
-    "\\s:missing-tagblock-checksum,q:u,c:1509502436,T:2017-11-01 02.13.56\\!AIVDM,1,1,,A,13`el0gP000H=3JN9jb>4?wb0>`<,0*00",
     "\\s:missing_field_delimiter,q:u,c1509502436,T:2017-11-01 02.13.56*50\\!AIVDM,1,1,,A,13`el0gP000H=3JN9jb>4?wb0>`<,0*7B",
     "\\s:bad_group,q:u,c:1509502436,T:2017-11-01 02.13.56*50\\!AIVDM,BAD,1,,A,13`el0gP000H=3JN9jb>4?wb0>`<,0*0D",
     "\\s:missing_checksum,q:u,c:1509502436,T:2017-11-01 02.13.56\\!AIVDM,BAD,1,,A,13`el0gP000H=3JN9jb>4?wb0>`<,0*0D",
+    "\\s:bad-pad-value,q:u,c:1509502436,T:2017-11-01 02.13.56\\!AIVDM,1,1,,A,13`el0gP000H=3JN9jb>4?wb0>`<,BAD*0D",
 ])
 def test_expand_nmea_fail(nmea):
     with pytest.raises(DecodeError):
-        tagblock, body, pad = expand_nmea(nmea, validate_checksum=True)
+        tagblock, body, pad = expand_nmea(nmea, validate_checksum=False)
 
 
 @pytest.mark.parametrize("nmea", [

--- a/tests/test_nmea.py
+++ b/tests/test_nmea.py
@@ -44,7 +44,7 @@ def test_expand_nmea(line, expected):
 ])
 def test_expand_nmea_fail(nmea):
     with pytest.raises(DecodeError):
-        tagblock, body, pad = expand_nmea(nmea)
+        tagblock, body, pad = expand_nmea(nmea, validate_checksum=True)
 
 
 @pytest.mark.parametrize("nmea", [

--- a/tests/test_tagblock.py
+++ b/tests/test_tagblock.py
@@ -61,6 +61,7 @@ def test_add_tagblock(t, nmea, overwrite, expected):
 @pytest.mark.parametrize("fields,expected", [
     ({}, '*00'),
     ({'z': 123}, 'z:123*70'),
+    ({'tagblock_relative_time': 123}, 'r:123*78'),
     ({'tagblock_timestamp': 123456789}, 'c:123456789*68'),
     ({'tagblock_timestamp': 123456789, 'tagblock_station': 'test'}, 'c:123456789,s:test*1B'),
     ({'tagblock_timestamp': 123456789,
@@ -79,6 +80,7 @@ def test_encode_tagblock(fields, expected):
 @pytest.mark.parametrize("tagblock_str,expected", [
     ('*00', {}),
     ('z:123*70', {'z': '123'}),
+    ('r:123*78', {'tagblock_relative_time': 123}),
     ('c:123456789*68',{'tagblock_timestamp': 123456789}),
     ('c:123456789,s:test,g:1-2-3*5A',
      {'tagblock_timestamp': 123456789,
@@ -102,3 +104,12 @@ def test_decode_tagblock(tagblock_str, expected):
 def test_decode_tagblock_invalid_checksum(tagblock_str):
     with pytest.raises(DecodeError, match='Invalid checksum'):
         tagblock.decode_tagblock(tagblock_str, validate_checksum=True)
+
+@pytest.mark.parametrize("tagblock_str", [
+    ('invalid'),
+    ('c:invalid'),
+    ('c:123456789,z'),
+])
+def test_decode_tagblock_invalid(tagblock_str):
+    with pytest.raises(DecodeError, match='Unable to decode tagblock string'):
+        tagblock.decode_tagblock(tagblock_str, validate_checksum=False)

--- a/tests/test_tagblock.py
+++ b/tests/test_tagblock.py
@@ -97,6 +97,7 @@ def test_decode_tagblock(tagblock_str, expected):
     ('c:123456789,s:invalid,g:1-2-3*5A'),
     ('c:123456789,s:invalid,g:1-2-3'),
     ('c:123456789,s:invalid,g:1-2-3*ZZ'),
+    ('s:missing-tagblock-checksum,q:u,c:1509502436,T:2017-11-01 02.13.56')
 ])
 def test_decode_tagblock_invalid_checksum(tagblock_str):
     with pytest.raises(DecodeError, match='Invalid checksum'):

--- a/tests/test_tagblock.py
+++ b/tests/test_tagblock.py
@@ -58,6 +58,7 @@ def test_join_tagblock(t, nmea, expected):
 def test_add_tagblock(t, nmea, overwrite, expected):
     assert expected == tagblock.add_tagblock(t, nmea, overwrite)
 
+
 @pytest.mark.parametrize("fields,expected", [
     ({}, '*00'),
     ({'z': 123}, 'z:123*70'),
@@ -81,7 +82,7 @@ def test_encode_tagblock(fields, expected):
     ('*00', {}),
     ('z:123*70', {'z': '123'}),
     ('r:123*78', {'tagblock_relative_time': 123}),
-    ('c:123456789*68',{'tagblock_timestamp': 123456789}),
+    ('c:123456789*68', {'tagblock_timestamp': 123456789}),
     ('c:123456789,s:test,g:1-2-3*5A',
      {'tagblock_timestamp': 123456789,
       'tagblock_station': 'test',
@@ -104,6 +105,7 @@ def test_decode_tagblock(tagblock_str, expected):
 def test_decode_tagblock_invalid_checksum(tagblock_str):
     with pytest.raises(DecodeError, match='Invalid checksum'):
         tagblock.decode_tagblock(tagblock_str, validate_checksum=True)
+
 
 @pytest.mark.parametrize("tagblock_str", [
     ('invalid'),


### PR DESCRIPTION
Deprecate `parseTagblock` which is imported from libais in favor of `spllit_tagblock` and `decode_tagblock`

Also add `encode_tagblock` which can be used with `join_tagblock` to add or modify and existing tagblock 

Closes #36
