### PR TITLE
Ignore empty fields within the tagblock when decoding

### DIFF
--- a/ais_tools/tagblock.py
+++ b/ais_tools/tagblock.py
@@ -132,7 +132,7 @@ def decode_tagblock(tagblock_str, validate_checksum=False):
     if validate_checksum and not is_checksum_valid(tagblock_str):
         raise DecodeError('Invalid checksum')
 
-    for field in tagblock.split(","):
+    for field in [field for field in tagblock.split(",") if field]:
         try:
             key, value = field.split(":")
 

--- a/tests/test_tagblock.py
+++ b/tests/test_tagblock.py
@@ -89,6 +89,7 @@ def test_encode_tagblock(fields, expected):
       'tagblock_sentence': 1,
       'tagblock_groupsize': 2,
       'tagblock_id': 3}),
+    ('s:rMT5858,*0E', {'tagblock_station': 'rMT5858'})  # test for issue #45
 ])
 def test_decode_tagblock(tagblock_str, expected):
     assert expected == tagblock.decode_tagblock(tagblock_str)


### PR DESCRIPTION
Fixes #45 

Ignore empty fields within the tagblock when decoding.

