### PR TITLE
Use nmea "talker" id in join

### DIFF
--- a/ais_tools/__init__.py
+++ b/ais_tools/__init__.py
@@ -2,12 +2,12 @@
 Tools for managing AIS messages
 """
 
-__version__ = 'v0.1.5'
+__version__ = 'v0.1.6.dev1'
 __author__ = 'Paul Woods'
 __email__ = 'paul@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/ais-tools'
 __license__ = """
-Copyright 2023 Global Fishing Watch
+Copyright 2024 Global Fishing Watch
 
 Authors:
 Paul Woods <paul@globalfishingwatch.org>

--- a/ais_tools/cli.py
+++ b/ais_tools/cli.py
@@ -120,11 +120,12 @@ def update_tagblock(input, output, station, text):
 )
 @click.argument('input', type=click.File('r'), default='-')
 @click.argument('output', type=click.File('w'), default='-')
-def decode(input, output):
+@click.option('-q', '--quiet', is_flag=True, help="Do not emit decode errors to console")
+def decode(input, output, quiet):
     decoder = AIVDM()
     for msg in Message.stream(input):
         msg = decoder.safe_decode(msg)
-        if 'error' in msg:
+        if not quiet and  'error' in msg:
             click.echo(msg['error'], err=True)
         output.write(json.dumps(msg))
         output.write('\n')

--- a/ais_tools/nmea.py
+++ b/ais_tools/nmea.py
@@ -25,6 +25,7 @@ def expand_nmea(line, validate_checksum=False):
         raise DecodeError('Invalid checksum')
 
     try:
+        tagblock['talker_id'] = fields[0][1:3]
         if 'tagblock_groupsize' not in tagblock:
             tagblock['tagblock_groupsize'] = int(fields[1])
             tagblock['tagblock_sentence'] = int(fields[2])
@@ -129,15 +130,16 @@ def join_multipart_stream(lines,
             # - tagblock_group_id if present, is a sequence number that is the same for all message parts, and it
             #                     should be locally unique within the stream. It is a 4-digit number
             # - tagblock_channel is the AIS RF channel (either A or B) that was used for transmission
+            # - talker_id is the first two characters after the '!'.  For a message "!AIVDM..." the talker_id is "AI"
 
             tagblock_group_id = tagblock.get('tagblock_group_id')
             if tagblock_group_id:
                 # only need this group id
-                key = (total_parts, None, tagblock_group_id, None)
+                key = (total_parts, None, tagblock_group_id, None, None)
             else:
                 # no group id present, so use everything else we have to try to make a locally unique signature
                 key = (total_parts, tagblock.get('tagblock_station'), tagblock.get('tagblock_id'),
-                       tagblock.get('tagblock_channel'))
+                       tagblock.get('tagblock_channel'), tagblock.get('talker_id'))
 
             # pack up the message part
             # - tagblock_sentence is the index of this part relative to the other parts, where the first part is 1


### PR DESCRIPTION
Use the "talker"id part of the nmea sentence when matching up parts of a multi part sentence so that parts of a message from one talker are not joined to parts from another talker.

For example a base station message uses `!BSVDM` and a vessel uses `!AIVDM` where`BS` and `AI` are the "talker".  When these are 2-part messages (type 5) they could end up combined if the message parts are interleaved unless we take into account that they are different "talkers"

