### PR TITLE
Fix regex in dedup_key computation

### DIFF
--- a/ais_tools/normalize.py
+++ b/ais_tools/normalize.py
@@ -5,7 +5,7 @@ import re
 from enum import Enum
 
 
-REGEX_NMEA = re.compile(r'!(?:AI|BS|AB)VDM[^*]+\*[0-9A-F]{2}')
+REGEX_NMEA = re.compile(r'!(?:AI|BS|AB)VDM[^*]+\*[0-9A-Fa-f]{2}')
 SKIP_MESSAGE_IF_FIELD_PRESENT = ['error']
 SKIP_MESSAGE_IF_FIELD_ABSENT = ['id', 'mmsi', 'tagblock_timestamp']
 AIS_TYPES = frozenset([1, 2, 3, 4, 5, 9, 11, 17, 18, 19, 21, 24, 27])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "ais-tools"
 description = "Tools for managing AIS messages"
 readme = "README.md"
-version = "v0.1.6.dev5"
+version = "v0.1.6.dev6"
 license = {file = "LICENSE"}
 authors = [
     {name = "Paul Woods", email = "paul@globalfishingwatch.org"},

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -204,6 +204,8 @@ def test_nmea_regex(value, expected):
     ({'nmea': '!BSVDM,2,2,2,A,@,0*57', 'tagblock_timestamp': 1707443048}, 'a6926b3f62eeb7d7'),
     ({'nmea': '!BSVDM,2,2,2,B,@,0*57', 'tagblock_timestamp': 1707443048}, 'd3972916d1a17048'),
     ({'nmea': 'invalid', 'tagblock_timestamp': 1707443048}, None),
+    ({"nmea": "!AIVDM,1,1,,A,H69@rrS3S?SR3G2D000000000000,0*2e",
+      "tagblock_timestamp": 1712156268}, '06f1f1b00815aa10'),
 ])
 def test_normalize_dedup_key(message, expected):
     assert normalize_dedup_key(message) == expected


### PR DESCRIPTION
Fix the regex in normalize_dedup_key to allow for lower case letters a-f in the checksum of the nmea