### PR TITLE
Normalize transmit timestamp for type 4 and type 11

### DIFF
--- a/ais_tools/normalize.py
+++ b/ais_tools/normalize.py
@@ -1,4 +1,4 @@
-from typing import Union, Optional, Any
+from typing import Optional, Any
 from datetime import datetime
 import hashlib
 import re
@@ -27,6 +27,24 @@ def normalize_timestamp(message: dict) -> Optional[str]:
         return datetime.utcfromtimestamp(message['tagblock_timestamp']).isoformat(timespec='seconds') + 'Z'
     else:
         return None
+
+
+def normalize_xmit_timestamp(message: dict) -> Optional[str]:
+    def in_range(value, valid_range):
+        return value is not None and valid_range[0] <= value <= valid_range[1]
+
+    fields = {
+        'year': (1, 9999),
+        'month': (1, 12),
+        'day': (1,31),
+        'hour': (0, 23),
+        'minute': (0, 59),
+        'second': (0, 59)
+    }
+    values = [(f, message.get(f), valid_range) for f, valid_range in fields.items()]
+    if all(in_range(value, valid_range) for _, value, valid_range in values):
+        values = {f: value for f, value, _ in values}
+        return datetime(**values).isoformat(timespec='seconds') + 'Z'
 
 
 def coord_type(val: float, _min: float, _max: float, unavailable: float) -> POSITION_TYPE:

--- a/ais_tools/normalize_transform.py
+++ b/ais_tools/normalize_transform.py
@@ -9,6 +9,7 @@ DEFAULT_FIELD_TRANSFORMS = (
     ('type', normalize.normalize_message_type, {}),
     ('ssvid', normalize.normalize_ssvid, {}),
     ('timestamp', normalize.normalize_timestamp, {}),
+    ('xmit_timestamp', normalize.normalize_xmit_timestamp, {}),
     ('lon', normalize.normalize_longitude, {}),
     ('lat', normalize.normalize_latitude, {}),
     ('pos_type', normalize.normalize_pos_type, {}),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "ais-tools"
 description = "Tools for managing AIS messages"
 readme = "README.md"
-version = "v0.1.6.dev7"
+version = "v0.1.6.dev8"
 license = {file = "LICENSE"}
 authors = [
     {name = "Paul Woods", email = "paul@globalfishingwatch.org"},

--- a/tests/test_aivdm.py
+++ b/tests/test_aivdm.py
@@ -17,7 +17,9 @@ from ais_tools.message import Message
     ('\\s:66,c:1662392695*3D\\!AIVDM,1,1,,A,E>j9dQjas000000000000000000@Ijfb?VJlh00808v>B0,4*0D',
         {'assigned_mode': False}),
     ('\\s:66,c:1663246931*35\\!AIVDM,1,1,,,9001?BP=h:qJ9vb;:f7EN1h240Rb,0*3F',
-        {'alt_sensor': 0, 'assigned_mode': False})
+        {'alt_sensor': 0, 'assigned_mode': False}),
+    ('\\c:1712130370,s:dynamic,t:spire*55\\!AIVDM,1,1,,A,403wboivQ1WfE`4gnt5MJT?024rp,0*24',
+     {'year': 2024, 'month': 4, 'day': 3, 'hour': 7, 'minute': 46, 'second': 21})
 ])
 def test_decode(nmea, expected):
     decoder = AIVDM()

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -2,6 +2,7 @@ import pytest
 import re
 
 from ais_tools.normalize import normalize_timestamp
+from ais_tools.normalize import normalize_xmit_timestamp
 from ais_tools.normalize import normalize_longitude
 from ais_tools.normalize import normalize_latitude
 from ais_tools.normalize import normalize_pos_type
@@ -33,6 +34,23 @@ from ais_tools.normalize import REGEX_NMEA
 def test_normalize_timestamp(t, expected):
     message = {'tagblock_timestamp': t}
     assert normalize_timestamp(message) == expected
+
+@pytest.mark.parametrize("year, month, day, hour, minute, second,expected", [
+    (2024, 1, 2, 3, 4, 5, '2024-01-02T03:04:05Z'),
+    (None, 1, 2, 3, 4, 5, None),
+    (2024, 0, 2, 3, 4, 5, None),
+    (2024, 1, 2, 3, 4, 60, None),
+])
+def test_normalize_xmit_timestamp(year, month, day, hour, minute, second, expected):
+    message = {
+        'year': year,
+        'month': month,
+        'day': day,
+        'hour': hour,
+        'minute': minute,
+        'second': second
+    }
+    assert normalize_xmit_timestamp(message) == expected
 
 
 @pytest.mark.parametrize("value,expected", [

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -288,6 +288,8 @@ def test_filter_message(message, expected):
     ({'type_and_cargo': 30}, {'shiptype': 'Fishing'}),
     ({'nmea': '!AIVDM,2,2,2,A,@,0*57', 'tagblock_timestamp': 1707443048},
         {'timestamp': '2024-02-09T01:44:08Z', 'dedup_key': '745f4bde2318c974'}),
+    ({'year': 2024, 'month': 4, 'day': 3, 'hour': 2, 'minute': 1, 'second': 0},
+        {'xmit_timestamp': '2024-04-03T02:01:00Z'})
 ])
 def test_normalize_message(message, expected):
     assert normalize_message(message, DEFAULT_FIELD_TRANSFORMS) == expected


### PR DESCRIPTION
Add a new field `xmit_timestamp` to the normalizer that encodes the year, month, day, hour, minute, and second values from type 4 and type 11 messages as a UTC datetime string