### PR TITLE
Don't fail on type 5 messages with bad padding value

### DIFF
--- a/ais_tools/ais.py
+++ b/ais_tools/ais.py
@@ -1,5 +1,6 @@
 from ais_tools.transcode import DecodeError
 from ais_tools.transcode import ASCII8toAIS6
+from ais_tools import ais5
 from ais_tools import ais8
 from ais_tools import ais9
 from ais_tools import ais18
@@ -18,6 +19,7 @@ encode_fn = {
 }
 
 decode_fn = {
+    5: ais5.ais5_decode,
     8: ais8.ais8_decode,
     9: ais9.ais9_decode,
     18: ais18.ais18_decode,

--- a/ais_tools/ais5.py
+++ b/ais_tools/ais5.py
@@ -1,0 +1,10 @@
+import ais as libais
+from ais import DecodeError
+
+
+def ais5_decode(body, pad):
+    try:
+        return libais.decode(body, 2)
+    except DecodeError as e:
+        raise DecodeError(f'TYPE 5 LIBAIS ERR: {str(e)}')
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "ais-tools"
 description = "Tools for managing AIS messages"
 readme = "README.md"
-version = "v0.1.6.dev9"
+version = "v0.1.6.dev10 "
 license = {file = "LICENSE"}
 authors = [
     {name = "Paul Woods", email = "paul@globalfishingwatch.org"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "ais-tools"
 description = "Tools for managing AIS messages"
 readme = "README.md"
-version = "v0.1.6.dev10 "
+version = "v0.1.7"
 license = {file = "LICENSE"}
 authors = [
     {name = "Paul Woods", email = "paul@globalfishingwatch.org"},

--- a/tests/test_ais.py
+++ b/tests/test_ais.py
@@ -82,6 +82,30 @@ def test_ais8_wrong_pad():
 
 
 @pytest.mark.parametrize("body,pad,expected", [
+    # incorrect padding
+    ('56:=31`000008QaF220QD60`T4pN3N2222222216>pN5@50e0ES2@C`6EC`1hCQp8888880', 0,
+     {'name': 'HUA JIANG 7         '}),
+    # correct padding
+    ('56:=31`000008QaF220QD60`T4pN3N2222222216>pN5@50e0ES2@C`6EC`1hCQp8888880', 2,
+     {'name': 'HUA JIANG 7         '})
+     ])
+def test_ais5(body, pad, expected):
+    msg = AISMessageTranscoder.decode_nmea(body, pad)
+    actual = {k: v for k, v in msg.items() if k in expected}
+    assert actual == expected
+
+
+@pytest.mark.parametrize("body,pad,expected", [
+    # incorrect padding
+    ('56:=31`000008QaF220QD60`T4pN3N2222222216>pN5@50e0ES2@C`6EC`1hCQp88888809999', 0,
+     'TYPE 5 LIBAIS ERR: Ais5: AIS_ERR_BAD_BIT_COUNT'),
+])
+def test_ais5_fail(body, pad, expected):
+    with pytest.raises(DecodeError, match=expected):
+        _ = AISMessageTranscoder.decode_nmea(body, pad)
+
+
+@pytest.mark.parametrize("body,pad,expected", [
     ('9001?BP=h:qJ9vb;:f7EN1h240Rb', 0, {'mmsi': 20298, 'alt': 55, 'sog': 10}),
     ('90009C3dRIM1QSsjSPAa1;h200T4', 0, {'mmsi': 2380, 'alt': 946, 'alt_sensor': 0}),
 ])

--- a/tests/test_aivdm.py
+++ b/tests/test_aivdm.py
@@ -89,13 +89,3 @@ def test_missing_part():
     msg = decoder.safe_decode(nmea=nmea, best_effort=True)
     assert msg['error'] == 'Expected 2 message parts to decode but found 1'
     assert msg['tagblock_timestamp'] == 1668472438
-
-
-@pytest.mark.parametrize("nmea", [
-    ('\\c:1711942361,s:terrestrial,t:spire*4B\\!AIVDM,1,1,,A,56:=31`000008QaF220QD60`T4pN3N2222222216>pN5@50e0ES2@C`6EC`1hCQp8888880,0*60'),
-    ('\\c:1711952914,s:terrestrial,t:spire*42\\!AIVDM,1,1,,A,56:Ib8P0000000000008DV09F1L4r1TTr374000j1p5320C=02U2ADj0CP000000000000:,0*03'),
-])
-def test_type_5_bad_padding(nmea):
-    decoder = AIVDM()
-    msg = decoder.safe_decode(nmea=nmea, best_effort=True)
-    assert 'error' not in msg

--- a/tests/test_aivdm.py
+++ b/tests/test_aivdm.py
@@ -89,3 +89,13 @@ def test_missing_part():
     msg = decoder.safe_decode(nmea=nmea, best_effort=True)
     assert msg['error'] == 'Expected 2 message parts to decode but found 1'
     assert msg['tagblock_timestamp'] == 1668472438
+
+
+@pytest.mark.parametrize("nmea", [
+    ('\\c:1711942361,s:terrestrial,t:spire*4B\\!AIVDM,1,1,,A,56:=31`000008QaF220QD60`T4pN3N2222222216>pN5@50e0ES2@C`6EC`1hCQp8888880,0*60'),
+    ('\\c:1711952914,s:terrestrial,t:spire*42\\!AIVDM,1,1,,A,56:Ib8P0000000000008DV09F1L4r1TTr374000j1p5320C=02U2ADj0CP000000000000:,0*03'),
+])
+def test_type_5_bad_padding(nmea):
+    decoder = AIVDM()
+    msg = decoder.safe_decode(nmea=nmea, best_effort=True)
+    assert 'error' not in msg


### PR DESCRIPTION
Overrride the padding value for type 5 message to force it to always be "2".   This addresses a problem we have encountered in the spire feed with padding values of "0" in type 5 messages that have been joined upstream .