### PR TITLE
Performance improvement in normalize_dedup_key()

### DIFF
--- a/ais_tools/normalize.py
+++ b/ais_tools/normalize.py
@@ -1,6 +1,6 @@
 from typing import Optional, Any
 from datetime import datetime
-import hashlib
+import xxhash
 import re
 from enum import Enum
 
@@ -168,16 +168,14 @@ def normalize_dedup_key(message: dict) -> Optional[str]:
     if 'nmea' not in message or 'tagblock_timestamp' not in message:
         return None
 
-    nmea = ''.join(re.findall(REGEX_NMEA, message['nmea']))
+    nmea = ''.join(REGEX_NMEA.findall(message['nmea']))
     if not nmea:
         return None     # no nmea found in message
 
     timestamp = int(message['tagblock_timestamp'] / 60)
 
     key = f'{nmea}_{timestamp}'.encode('utf-8')
-    h = hashlib.sha1()
-    h.update(key)
-    return h.hexdigest()[:16]
+    return xxhash.xxh3_64_hexdigest(key)
 
 
 def map_field(message: dict, source_field: str = None) -> Optional[Any]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "bitarray",
     "cbitstruct",
     "udatetime",
+    "xxhash"
 ]
 
 [project.urls]

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -229,12 +229,12 @@ def test_nmea_regex(value, expected):
 
 @pytest.mark.parametrize("message,expected", [
     ({'tagblock_timestamp': 1707443048}, None),
-    ({'nmea': '!AIVDM,2,2,2,A,@,0*57', 'tagblock_timestamp': 1707443048}, '745f4bde2318c974'),
-    ({'nmea': '!BSVDM,2,2,2,A,@,0*57', 'tagblock_timestamp': 1707443048}, 'a6926b3f62eeb7d7'),
-    ({'nmea': '!BSVDM,2,2,2,B,@,0*57', 'tagblock_timestamp': 1707443048}, 'd3972916d1a17048'),
+    ({'nmea': '!AIVDM,2,2,2,A,@,0*57', 'tagblock_timestamp': 1707443048}, '784dcbf153c04531'),
+    ({'nmea': '!BSVDM,2,2,2,A,@,0*57', 'tagblock_timestamp': 1707443048}, 'da0adb5959aec091'),
+    ({'nmea': '!BSVDM,2,2,2,B,@,0*57', 'tagblock_timestamp': 1707443048}, '70bbc54a4bfc5daa'),
     ({'nmea': 'invalid', 'tagblock_timestamp': 1707443048}, None),
     ({"nmea": "!AIVDM,1,1,,A,H69@rrS3S?SR3G2D000000000000,0*2e",
-      "tagblock_timestamp": 1712156268}, '06f1f1b00815aa10'),
+      "tagblock_timestamp": 1712156268}, 'e804595091021cd8'),
     ({'nmea': '!AIVDM', 'tagblock_timestamp': 0}, None),
 ])
 def test_normalize_dedup_key(message, expected):
@@ -287,7 +287,7 @@ def test_filter_message(message, expected):
     ({'dim_c': 1, 'dim_d': 1}, {'width': 2}),
     ({'type_and_cargo': 30}, {'shiptype': 'Fishing'}),
     ({'nmea': '!AIVDM,2,2,2,A,@,0*57', 'tagblock_timestamp': 1707443048},
-        {'timestamp': '2024-02-09T01:44:08Z', 'dedup_key': '745f4bde2318c974'}),
+        {'timestamp': '2024-02-09T01:44:08Z', 'dedup_key': '784dcbf153c04531'}),
     ({'year': 2024, 'month': 4, 'day': 3, 'hour': 2, 'minute': 1, 'second': 0},
         {'tx_timestamp': '2024-04-03T02:01:00Z'})
 ])

--- a/utils/perf-test.py
+++ b/utils/perf-test.py
@@ -3,6 +3,7 @@ import cProfile
 import pstats
 from pstats import SortKey
 from ais_tools.aivdm import AIVDM, AisToolsDecoder
+from ais_tools.normalize import normalize_dedup_key
 # from ais_tools.aivdm import LibaisDecoder
 
 
@@ -60,6 +61,14 @@ def full_decode(n):
         msg.add_parser_version()
 
 
+def test_normalize_dedup_key(n):
+    msg = {
+        'tagblock_timestamp': 123456789,
+        'nmea': "\\!AIVDM,2,1,1,B,5:U7dET2B4iE17KOS:0@Di0PTqE>22222222220l1@F65ut8?=lhCU3l,0*71"
+    }
+    for i in range (n):
+        _ = normalize_dedup_key(msg)
+
 def run_perf_test(func):
     cProfile.run(func, 'perf-test.stats')
 
@@ -68,7 +77,7 @@ def run_perf_test(func):
 
 
 def main():
-    run_perf_test('decode(10000)')
+    run_perf_test('test_normalize_dedup_key(1000000)')
     # run_perf_test('full_decode(100000)')
     # checksum_compare()
 


### PR DESCRIPTION
Improve performance of normalize_dedup_key() by ~3x by
* Use a pre-compiled regex
* Use xxhash instead of hashlib to compute the hash
