### PR TITLE
Catch edge case where day value in tx_timestamp is invalid for the given month

### DIFF
--- a/ais_tools/normalize.py
+++ b/ais_tools/normalize.py
@@ -36,7 +36,7 @@ def normalize_tx_timestamp(message: dict) -> Optional[str]:
     fields = {
         'year': (1, 9999),
         'month': (1, 12),
-        'day': (1,31),
+        'day': (1, 31),
         'hour': (0, 23),
         'minute': (0, 59),
         'second': (0, 59)
@@ -44,7 +44,10 @@ def normalize_tx_timestamp(message: dict) -> Optional[str]:
     values = [(f, message.get(f), valid_range) for f, valid_range in fields.items()]
     if all(in_range(value, valid_range) for _, value, valid_range in values):
         values = {f: value for f, value, _ in values}
-        return datetime(**values).isoformat(timespec='seconds') + 'Z'
+        try:
+            return datetime(**values).isoformat(timespec='seconds') + 'Z'
+        except ValueError:
+            return None
 
 
 def coord_type(val: float, _min: float, _max: float, unavailable: float) -> POSITION_TYPE:

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -289,7 +289,9 @@ def test_filter_message(message, expected):
     ({'nmea': '!AIVDM,2,2,2,A,@,0*57', 'tagblock_timestamp': 1707443048},
         {'timestamp': '2024-02-09T01:44:08Z', 'dedup_key': '784dcbf153c04531'}),
     ({'year': 2024, 'month': 4, 'day': 3, 'hour': 2, 'minute': 1, 'second': 0},
-        {'tx_timestamp': '2024-04-03T02:01:00Z'})
+        {'tx_timestamp': '2024-04-03T02:01:00Z'}),
+    ({'year': 2024, 'month': 2, 'day': 31, 'hour': 0, 'minute': 0, 'second': 0},
+        {}),
 ])
 def test_normalize_message(message, expected):
     assert normalize_message(message, DEFAULT_FIELD_TRANSFORMS) == expected


### PR DESCRIPTION
In normalize we conver the tx_timestamp from separate fields for each of the datetime parts.  The valid range for the day field according to the AIS spec is 1-31, but this allows for invalid dates when combined with the month field. 

Added a try...except block to catch the conversion failures and return None for tx_timestamp in this case.