### PR TITLE
Fix memory leak in c implementation of checksum

### DIFF
--- a/ais_tools/core/methods.c
+++ b/ais_tools/core/methods.c
@@ -8,45 +8,69 @@
 PyObject *
 method_compute_checksum(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
+    PyObject *py_str;
+    PyObject *result;
     const char *str;
 
     if (nargs != 1)
         return PyErr_Format(PyExc_TypeError, "compute_checksum expects 1 argument");
 
-    str = PyUnicode_AsUTF8(PyObject_Str(args[0]));
-    return PyLong_FromLong(checksum(str));
+    py_str = PyObject_Str(args[0]);
+
+    str = PyUnicode_AsUTF8(py_str);
+
+    result = PyLong_FromLong(checksum(str));
+
+    Py_DECREF(py_str);
+
+    return result;
 }
 
 PyObject *
 method_compute_checksum_str(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
+    PyObject *py_str;
+    PyObject *result;
     const char *str;
     char c_str[3];
 
     if (nargs != 1)
         return PyErr_Format(PyExc_TypeError, "checksum_str expects 1 argument");
 
-    str = PyUnicode_AsUTF8(PyObject_Str(args[0]));
+    py_str = PyObject_Str(args[0]);
+
+    str = PyUnicode_AsUTF8(py_str);
+
     checksum_str(c_str, str, ARRAY_LENGTH(c_str));
-    return PyUnicode_FromString(c_str);
+
+    result = PyUnicode_FromString(c_str);
+
+    Py_DECREF(py_str);
+
+    return result;
 }
 
 PyObject *
 method_is_checksum_valid(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
+    PyObject *py_str;
+    PyObject *result;
     const char *str;
     char buffer[MAX_SENTENCE_LENGTH];
 
     if (nargs != 1)
         return PyErr_Format(PyExc_TypeError, "checksum_str expects 1 argument");
 
-    str = PyUnicode_AsUTF8(PyObject_Str(args[0]));
+    py_str = PyObject_Str(args[0]);
+
+    str = PyUnicode_AsUTF8(py_str);
 
     if (safe_strcpy(buffer, str, ARRAY_LENGTH(buffer)) >= ARRAY_LENGTH(buffer))
-        return PyErr_Format(PyExc_ValueError, "String too long");
-
-    if (is_checksum_valid(buffer))
-        Py_RETURN_TRUE;
+        result = PyErr_Format(PyExc_ValueError, "String too long");
     else
-        Py_RETURN_FALSE;
+        result = is_checksum_valid(buffer) ?  Py_NewRef(Py_True) :  Py_NewRef(Py_False);
+
+    Py_DECREF(py_str);
+
+    return result;
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "ais-tools"
 description = "Tools for managing AIS messages"
 readme = "README.md"
-version = "v0.1.7"
+version = "v0.1.7.dev1"
 license = {file = "LICENSE"}
 authors = [
     {name = "Paul Woods", email = "paul@globalfishingwatch.org"},

--- a/utils/mem-test.py
+++ b/utils/mem-test.py
@@ -1,0 +1,21 @@
+
+from memory_profiler import profile
+
+from ais_tools.core import checksum
+from ais_tools.core import checksum_str
+from ais_tools.core import is_checksum_valid
+
+def run_checksum(n):
+    for i in range(n):
+        str = ''.join(['a','b'])
+        c = checksum(str)
+        c = checksum_str(str)
+        c = is_checksum_valid(str)
+
+
+@profile
+def run_test():
+    run_checksum(1000000)
+
+
+run_test()


### PR DESCRIPTION
Fixed a memory leak where a python object was not being dereferenced in the core C library