### PR TITLE
Remove unneeded dependency on deprecated cdefs.h in core

### DIFF
--- a/ais_tools/core/strcpy.c
+++ b/ais_tools/core/strcpy.c
@@ -1,4 +1,3 @@
-#include <sys/cdefs.h>
 #include <sys/types.h>
 
 /*


### PR DESCRIPTION
In the C module, remove `#include <cdefs.h>` which was not needed and generates a deprecation warning