### PR TITLE
Update for bitarray 3.0.0

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-11
+          - macos-latest
           - ubuntu-latest
         python-version:
           - "3.8"

--- a/ais_tools/ais25.py
+++ b/ais_tools/ais25.py
@@ -22,7 +22,7 @@ def ais25_decode(body, pad):
         # assume that the pad value was wrong and just ignore the extra bits at the end
         new_len = (len(text_bits) // 6) * 6
         text_bits = text_bits[:new_len]
-    message['text'] = ''.join(text_bits.iterdecode(ASCII8toASCII6_decode_tree))
+    message['text'] = ''.join(text_bits.decode(ASCII8toASCII6_decode_tree))
 
     return message
 

--- a/ais_tools/transcode.py
+++ b/ais_tools/transcode.py
@@ -30,7 +30,7 @@ def bits_to_nmea(bits):
         pad = 0
     else:
         bits = bits + (pad * bitarray('0'))
-    return ''.join(bits.iterdecode(ASCII8toAIS6_decode_tree)), pad
+    return ''.join(bits.decode(ASCII8toAIS6_decode_tree)), pad
 
 
 def nmea_to_bits(body, pad):
@@ -73,7 +73,7 @@ class NmeaBits:
             bits = self.bits
         else:
             bits = self.bits + (pad * bitarray('0'))
-        return ''.join(bits.iterdecode(ASCII8toAIS6_decode_tree)), pad
+        return ''.join(bits.decode(ASCII8toAIS6_decode_tree)), pad
 
     def pack(self, struct, message):
         self.pack_into(struct, self.offset, message)
@@ -225,4 +225,4 @@ class ASCII6Field(EncodedField):
         bits = bitarray()
         bits.frombytes(value)
         bits = bits[:self.nbits]
-        return ''.join(bits.iterdecode(ASCII8toASCII6_decode_tree))
+        return ''.join(bits.decode(ASCII8toASCII6_decode_tree))


### PR DESCRIPTION
Fixes #69 

update usage for breaking changes with bitarray 3.0.0
update CI to use macos-latest instead of macos-11

