### PR TITLE
Allow extra bits in type 5 messages

### DIFF
--- a/ais_tools/ais5.py
+++ b/ais_tools/ais5.py
@@ -4,6 +4,9 @@ from ais import DecodeError
 
 def ais5_decode(body, pad):
     try:
+        # NB: we ignore any extra bits in the body, so we only take the first 71 characters
+        # because libais will raise an exception if the body with pad is not exactly 424 bits.
+        # 6 bits per character less the 2 padding bits (71 * 6 - 2 = 424)
         return libais.decode(body[:71], 2)
     except DecodeError as e:
         raise DecodeError(f'TYPE 5 LIBAIS ERR: {str(e)}')

--- a/ais_tools/ais5.py
+++ b/ais_tools/ais5.py
@@ -4,7 +4,7 @@ from ais import DecodeError
 
 def ais5_decode(body, pad):
     try:
-        return libais.decode(body, 2)
+        return libais.decode(body[:71], 2)
     except DecodeError as e:
         raise DecodeError(f'TYPE 5 LIBAIS ERR: {str(e)}')
 

--- a/ais_tools/ais5.py
+++ b/ais_tools/ais5.py
@@ -4,10 +4,16 @@ from ais import DecodeError
 
 def ais5_decode(body, pad):
     try:
-        # NB: we ignore any extra bits in the body, so we only take the first 71 characters
-        # because libais will raise an exception if the body with pad is not exactly 424 bits.
+        # NB: ignore any extra bits in the body if there is a single extra character or extra padding bts.
+        # This is based on observations that there are many type 5 messages occurring in the wild that have
+        # a pad value of '0' and/or a single extra character, but appear to be valid messages.
+        # We take the first 71 characters because libais will raise an exception if the body with pad
+        # is not exactly 424 bits.
         # 6 bits per character less the 2 padding bits (71 * 6 - 2 = 424)
-        return libais.decode(body[:71], 2)
+
+        if (71 <= len(body) <= 72):
+            body = body[:71]
+        return libais.decode(body, 2)
     except DecodeError as e:
         raise DecodeError(f'TYPE 5 LIBAIS ERR: {str(e)}')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "ais-tools"
 description = "Tools for managing AIS messages"
 readme = "README.md"
-version = "v0.1.7"
+version = "v0.1.8dev"
 license = {file = "LICENSE"}
 authors = [
     {name = "Paul Woods", email = "paul@globalfishingwatch.org"},

--- a/tests/test_ais.py
+++ b/tests/test_ais.py
@@ -87,7 +87,10 @@ def test_ais8_wrong_pad():
      {'name': 'HUA JIANG 7         '}),
     # correct padding
     ('56:=31`000008QaF220QD60`T4pN3N2222222216>pN5@50e0ES2@C`6EC`1hCQp8888880', 2,
-     {'name': 'HUA JIANG 7         '})
+     {'name': 'HUA JIANG 7         '}),
+    # too many bits
+    ('538UMb82F1cOD9MOD019E<4@U8000000000000157av:E58k0?SAC2C30@00000000000080', 0,
+     {'name': 'RUSADIR@@@@@@@@@@@@@'})
      ])
 def test_ais5(body, pad, expected):
     msg = AISMessageTranscoder.decode_nmea(body, pad)
@@ -96,8 +99,8 @@ def test_ais5(body, pad, expected):
 
 
 @pytest.mark.parametrize("body,pad,expected", [
-    # incorrect padding
-    ('56:=31`000008QaF220QD60`T4pN3N2222222216>pN5@50e0ES2@C`6EC`1hCQp88888809999', 0,
+    # not enough bits
+    ('56:=31`000008QaF220QD60`T4pN3N2222222216>pN5@50e0ES2@C`6EC`1hCQp888888', 0,
      'TYPE 5 LIBAIS ERR: Ais5: AIS_ERR_BAD_BIT_COUNT'),
 ])
 def test_ais5_fail(body, pad, expected):

--- a/tests/test_ais.py
+++ b/tests/test_ais.py
@@ -88,7 +88,7 @@ def test_ais8_wrong_pad():
     # correct padding
     ('56:=31`000008QaF220QD60`T4pN3N2222222216>pN5@50e0ES2@C`6EC`1hCQp8888880', 2,
      {'name': 'HUA JIANG 7         '}),
-    # too many bits
+    # too many bits - one extra char
     ('538UMb82F1cOD9MOD019E<4@U8000000000000157av:E58k0?SAC2C30@00000000000080', 0,
      {'name': 'RUSADIR@@@@@@@@@@@@@'})
      ])
@@ -101,6 +101,9 @@ def test_ais5(body, pad, expected):
 @pytest.mark.parametrize("body,pad,expected", [
     # not enough bits
     ('56:=31`000008QaF220QD60`T4pN3N2222222216>pN5@50e0ES2@C`6EC`1hCQp888888', 0,
+     'TYPE 5 LIBAIS ERR: Ais5: AIS_ERR_BAD_BIT_COUNT'),
+    # too many bits - 2 extra chars
+    ('538UMb82F1cOD9MOD019E<4@U8000000000000157av:E58k0?SAC2C30@000000000000800', 0,
      'TYPE 5 LIBAIS ERR: Ais5: AIS_ERR_BAD_BIT_COUNT'),
 ])
 def test_ais5_fail(body, pad, expected):


### PR DESCRIPTION
Ignore extra bits at the end of type 5 messages, just like we already do with type 1, 2 and 3.

Fixes #71 

Connects https://globalfishingwatch.atlassian.net/browse/PIPELINE-2478