### PR TITLE
Remove use of deprecated datetime.utcnow()

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,11 +19,10 @@ jobs:
           - macos-latest
           - ubuntu-latest
         python-version:
-          - "3.8"
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
     steps:
     - name: Checkout source
       uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![build](https://github.com/GlobalFishingWatch/ais-tools/workflows/Python%20package/badge.svg)
-![python](https://img.shields.io/badge/python-3.8+-blue.svg)
+![python](https://img.shields.io/badge/python-3.10+-blue.svg)
 [![codecov](https://codecov.io/gh/GlobalFishingWatch/ais-tools/branch/master/graph/badge.svg)](https://codecov.io/gh/GlobalFishingWatch/ais-tools)
 [![license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 

--- a/ais_tools/nmea.py
+++ b/ais_tools/nmea.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
-from datetime import datetime
-from datetime import UTC
+from datetime import datetime, timezone
 import re
 
 from ais import DecodeError
@@ -116,7 +115,7 @@ def join_multipart_stream(lines,
             else:
                 raise
 
-        now = datetime.now(UTC).timestamp()
+        now = datetime.now(timezone.utc).timestamp()
         total_parts = tagblock['tagblock_groupsize']
 
         if total_parts == 1:

--- a/ais_tools/nmea.py
+++ b/ais_tools/nmea.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from datetime import datetime
+from datetime import UTC
 import re
 
 from ais import DecodeError
@@ -115,7 +116,7 @@ def join_multipart_stream(lines,
             else:
                 raise
 
-        now = datetime.utcnow().timestamp()
+        now = datetime.now(UTC).timestamp()
         total_parts = tagblock['tagblock_groupsize']
 
         if total_parts == 1:

--- a/ais_tools/normalize.py
+++ b/ais_tools/normalize.py
@@ -1,5 +1,5 @@
 from typing import Optional, Any
-from datetime import datetime
+from datetime import datetime, timezone
 import xxhash
 import re
 from enum import Enum
@@ -24,7 +24,8 @@ def normalize_timestamp(message: dict) -> Optional[str]:
     # convert to RFC3339 string
     t = message.get('tagblock_timestamp')
     if t is not None:
-        return datetime.utcfromtimestamp(message['tagblock_timestamp']).isoformat(timespec='seconds') + 'Z'
+        t = datetime.fromtimestamp(t, tz=timezone.utc)
+        return t.isoformat(timespec='seconds').replace("+00:00", "Z")
     else:
         return None
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -66,12 +66,13 @@ def test_decode():
 
 
 def test_decode_fail():
-    runner = CliRunner(mix_stderr=False)
+    # runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     input = 'INVALID NMEA'
     result = runner.invoke(decode, input=input)
     assert not result.exception
     assert result.stderr.strip() == 'no valid AIVDM message detected'
-    msg = json.loads(result.output)
+    msg = json.loads(result.stdout)
     assert msg['error'] == 'no valid AIVDM message detected'
 
 
@@ -84,12 +85,13 @@ def test_encode():
 
 
 def test_encode_fail():
-    runner = CliRunner(mix_stderr=False)
+    # runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     input = 'INVALID JSON'
     result = runner.invoke(encode, input=input)
     assert not result.exception
     assert result.stderr.strip() == 'AISTOOLS ERR: Failed to encode unknown message type None'
-    assert result.output.strip() == '!AIVDM,1,1,,A,I0000000@002a97a0,5*16'
+    assert result.stdout.strip() == '!AIVDM,1,1,,A,I0000000@002a97a0,5*16'
 
 
 def test_join_multipart():


### PR DESCRIPTION
BREAKING CHANGE - no longer supports Python 3.8 and 3.9

Replace deprecated use of datetime.utcnow() and datetime.utcfromtimestamp()

closes #75

Dropping Python 3.8 and 3.9 in order to be compatible with Click 8.3.0, which only supports python 3.10+