### PR TITLE
Remove commented-out code in tagblock.py

### DIFF
--- a/ais_tools/tagblock.py
+++ b/ais_tools/tagblock.py
@@ -9,11 +9,6 @@ from ais import DecodeError
 from ais_tools.core import checksum_str
 from ais_tools.core import is_checksum_valid
 
-# import warnings
-# with warnings.catch_warnings():
-#     warnings.simplefilter("ignore")
-#     from ais.stream import parseTagBlock                # noqa: F401
-
 TAGBLOCK_T_FORMAT = '%Y-%m-%d %H.%M.%S'
 
 


### PR DESCRIPTION
## Summary
- Remove old commented-out import of `ais.stream.parseTagBlock`

## Test plan
- [x] No functional change

🤖 Generated with [Claude Code](https://claude.com/claude-code)